### PR TITLE
Update handlers for deposited amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,17 @@
     "build": "graph build",
     "test": "graph test",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ beanstalk",
-    "create-local": "graph create --node http://graph.playgrounds.academy:8020/ beanstalk",
-    "remove-local": "graph remove --node http://graph.playgrounds.academy:8020/ beanstalk",
-    "deploy-local": "graph deploy --node http://graph.playgrounds.academy:8020/ --ipfs http://graph.playgrounds.academy:5001 beanstalk",
-    "deploy-hosted": "graph deploy --product hosted-service cujowolf/beanstalk"
+    "create-local": "graph create --node http://graph.node.bean.money:8020/ beanstalk",
+    "remove-local": "graph remove --node http://graph.node.bean.money:8020/ beanstalk",
+    "deploy-local": "graph deploy --node http://graph.node.bean.money:8020/ --ipfs http://graph.node.bean.money:5001 beanstalk",
+    "create-local-dev": "graph create --node http://graph.node.bean.money:8020/ beanstalk-dev",
+    "remove-local-dev": "graph remove --node http://graph.node.bean.money:8020/ beanstalk-dev",
+    "deploy-local-dev": "graph deploy --node http://graph.node.bean.money:8020/ --ipfs http://graph.node.bean.money:5001 beanstalk-dev",
+    "create-local-test": "graph create --node http://graph.node.bean.money:8020/ beanstalk-testing",
+    "remove-local-test": "graph remove --node http://graph.node.bean.money:8020/ beanstalk-testing",
+    "deploy-local-test": "graph deploy --node http://graph.node.bean.money:8020/ --ipfs http://graph.node.bean.money:5001 beanstalk-testing",
+    "deploy-hosted": "graph deploy --product hosted-service cujowolf/beanstalk",
+    "deploy-hosted-dev": "graph deploy --product hosted-service cujowolf/beanstalk-dev"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.30.4",

--- a/schema.graphql
+++ b/schema.graphql
@@ -202,6 +202,7 @@ type SiloHourlySnapshot @entity {
   hourlyFarmers: Int!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 type SiloDailySnapshot @entity {
@@ -230,6 +231,7 @@ type SiloDailySnapshot @entity {
   dailyFarmers: Int!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 type SiloAsset @entity {
@@ -242,6 +244,7 @@ type SiloAsset @entity {
   cumulativeDepositedUSD: BigDecimal!
   totalStalk: BigInt!
   totalSeeds: BigInt!
+  totalFarmAmount: BigInt!
   hourlySnapshots: [SiloAssetHourlySnapshot!]! @derivedFrom(field: "siloAsset")
   dailySnapshots: [SiloAssetDailySnapshot!]! @derivedFrom(field: "siloAsset")
 }
@@ -256,14 +259,17 @@ type SiloAssetHourlySnapshot @entity {
   totalStalk: BigInt!
   totalSeeds: BigInt!
   cumulativeDepositedUSD: BigDecimal!
+  totalFarmAmount: BigInt!
   hourlyDepositedUSD: BigDecimal!
   hourlyDepositedBDV: BigInt!
   hourlyDepositedAmount: BigInt!
   hourlyWithdrawnAmount: BigInt!
   hourlyStalkDelta: BigInt!
   hourlySeedsDelta: BigInt!
+  hourlyFarmAmountDelta: BigInt!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 type SiloAssetDailySnapshot @entity {
@@ -276,14 +282,17 @@ type SiloAssetDailySnapshot @entity {
   totalStalk: BigInt!
   totalSeeds: BigInt!
   cumulativeDepositedUSD: BigDecimal!
+  totalFarmAmount: BigInt!
   dailyDepositedUSD: BigDecimal!
   dailyDepositedBDV: BigInt!
   dailyDepositedAmount: BigInt!
   dailyWithdrawnAmount: BigInt!
   dailyStalkDelta: BigInt!
   dailySeedsDelta: BigInt!
+  dailyFarmAmountDelta: BigInt!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 type Field @entity {

--- a/src/FarmHandler.ts
+++ b/src/FarmHandler.ts
@@ -1,0 +1,40 @@
+import { Address, BigInt } from "@graphprotocol/graph-ts";
+import { InternalBalanceChanged } from "../generated/Farm/Beanstalk";
+import { loadBeanstalk } from "./utils/Beanstalk";
+import { BEANSTALK } from "./utils/Constants";
+import { loadSiloAsset, loadSiloAssetDailySnapshot, loadSiloAssetHourlySnapshot } from "./utils/SiloAsset";
+import { loadFarmer } from "./utils/Farmer";
+
+
+export function handleInternalBalanceChanged(event: InternalBalanceChanged): void {
+
+    let beanstalk = loadBeanstalk(BEANSTALK)
+
+    loadFarmer(event.params.user)
+
+    updateFarmTotals(BEANSTALK, event.params.token, beanstalk.lastSeason, event.params.delta, event.block.number, event.block.timestamp)
+    updateFarmTotals(event.params.user, event.params.token, beanstalk.lastSeason, event.params.delta, event.block.number, event.block.timestamp)
+
+}
+
+function updateFarmTotals(account: Address, token: Address, season: i32, delta: BigInt, blockNumber: BigInt, timestamp: BigInt): void {
+    let asset = loadSiloAsset(account, token)
+    let assetHourly = loadSiloAssetHourlySnapshot(account, token, season, timestamp)
+    let assetDaily = loadSiloAssetDailySnapshot(account, token, timestamp)
+
+    asset.totalFarmAmount = asset.totalFarmAmount.plus(delta)
+    asset.save()
+
+    assetHourly.totalFarmAmount = asset.totalFarmAmount
+    assetHourly.hourlyFarmAmountDelta = assetHourly.hourlyFarmAmountDelta.plus(delta)
+    assetHourly.blockNumber = blockNumber
+    assetHourly.lastUpdated = timestamp
+    assetHourly.save()
+
+    assetDaily.season = season
+    assetDaily.totalFarmAmount = asset.totalFarmAmount
+    assetDaily.dailyFarmAmountDelta = assetDaily.dailyFarmAmountDelta.plus(delta)
+    assetDaily.blockNumber = blockNumber
+    assetDaily.lastUpdated = timestamp
+    assetDaily.save()
+}

--- a/src/utils/Silo.ts
+++ b/src/utils/Silo.ts
@@ -1,8 +1,7 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts";
-import { SiloDailySnapshot } from "../../generated/schema";
-import { Silo, SiloHourlySnapshot } from "../../generated/schema";
+import { Silo, SiloHourlySnapshot, SiloDailySnapshot } from "../../generated/schema";
 import { BEANSTALK } from "./Constants";
-import { dayFromTimestamp } from "./Dates";
+import { dayFromTimestamp, hourFromTimestamp } from "./Dates";
 import { ZERO_BD, ZERO_BI } from "./Decimals";
 
 export function loadSilo(account: Address): Silo {
@@ -21,10 +20,11 @@ export function loadSilo(account: Address): Silo {
         silo.totalFarmers = 0
         silo.save()
     }
-    return silo
+    return silo as Silo
 }
 
 export function loadSiloHourlySnapshot(account: Address, season: i32, timestamp: BigInt): SiloHourlySnapshot {
+    let hour = hourFromTimestamp(timestamp)
     let id = account.toHexString() + '-' + season.toString()
     let snapshot = SiloHourlySnapshot.load(id)
     if (snapshot == null) {
@@ -53,10 +53,11 @@ export function loadSiloHourlySnapshot(account: Address, season: i32, timestamp:
         snapshot.hourlyBeanMints = ZERO_BI
         snapshot.hourlyFarmers = 0
         snapshot.blockNumber = ZERO_BI
-        snapshot.timestamp = timestamp
+        snapshot.timestamp = BigInt.fromString(hour)
+        snapshot.lastUpdated = timestamp
         snapshot.save()
     }
-    return snapshot
+    return snapshot as SiloHourlySnapshot
 }
 
 export function loadSiloDailySnapshot(account: Address, timestamp: BigInt): SiloDailySnapshot {
@@ -89,7 +90,8 @@ export function loadSiloDailySnapshot(account: Address, timestamp: BigInt): Silo
         snapshot.dailyBeanMints = ZERO_BI
         snapshot.dailyFarmers = 0
         snapshot.blockNumber = ZERO_BI
-        snapshot.timestamp = timestamp
+        snapshot.timestamp = BigInt.fromString(day)
+        snapshot.lastUpdated = timestamp
         snapshot.save()
     }
     return snapshot as SiloDailySnapshot

--- a/src/utils/SiloAsset.ts
+++ b/src/utils/SiloAsset.ts
@@ -1,8 +1,7 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts';
-import { SiloAsset, SiloAssetDailySnapshot, SiloAssetHourlySnapshot } from '../../generated/schema'
-import { dayFromTimestamp } from './Dates';
+import { SiloAsset, SiloAssetHourlySnapshot, SiloAssetDailySnapshot } from '../../generated/schema'
+import { dayFromTimestamp, hourFromTimestamp } from './Dates';
 import { ZERO_BD, ZERO_BI } from './Decimals';
-import { loadToken } from './Token';
 
 export function loadSiloAsset(account: Address, token: Address): SiloAsset {
     let id = account.toHexString() + '-' + token.toHexString()
@@ -19,12 +18,14 @@ export function loadSiloAsset(account: Address, token: Address): SiloAsset {
         asset.cumulativeDepositedUSD = ZERO_BD
         asset.totalStalk = ZERO_BI
         asset.totalSeeds = ZERO_BI
+        asset.totalFarmAmount = ZERO_BI
         asset.save()
     }
     return asset as SiloAsset
 }
 
-export function loadSiloAssetHourlySnapshot(account: Address, token: Address, season: i32): SiloAssetHourlySnapshot {
+export function loadSiloAssetHourlySnapshot(account: Address, token: Address, season: i32, timestamp: BigInt): SiloAssetHourlySnapshot {
+    let hour = hourFromTimestamp(timestamp)
     let id = account.toHexString() + '-' + token.toHexString() + '-' + season.toString()
     let snapshot = SiloAssetHourlySnapshot.load(id)
     if (snapshot == null) {
@@ -38,14 +39,17 @@ export function loadSiloAssetHourlySnapshot(account: Address, token: Address, se
         snapshot.totalStalk = asset.totalStalk
         snapshot.totalSeeds = asset.totalSeeds
         snapshot.cumulativeDepositedUSD = asset.cumulativeDepositedUSD
+        snapshot.totalFarmAmount = asset.totalFarmAmount
         snapshot.hourlyDepositedUSD = ZERO_BD
         snapshot.hourlyDepositedBDV = ZERO_BI
         snapshot.hourlyDepositedAmount = ZERO_BI
         snapshot.hourlyWithdrawnAmount = ZERO_BI
         snapshot.hourlyStalkDelta = ZERO_BI
         snapshot.hourlySeedsDelta = ZERO_BI
+        snapshot.hourlyFarmAmountDelta = ZERO_BI
         snapshot.blockNumber = ZERO_BI
-        snapshot.timestamp = ZERO_BI
+        snapshot.timestamp = BigInt.fromString(hour)
+        snapshot.lastUpdated = ZERO_BI
         snapshot.save()
     }
     return snapshot as SiloAssetHourlySnapshot
@@ -66,14 +70,17 @@ export function loadSiloAssetDailySnapshot(account: Address, token: Address, tim
         snapshot.totalStalk = asset.totalStalk
         snapshot.totalSeeds = asset.totalSeeds
         snapshot.cumulativeDepositedUSD = asset.cumulativeDepositedUSD
+        snapshot.totalFarmAmount = asset.totalFarmAmount
         snapshot.dailyDepositedUSD = ZERO_BD
         snapshot.dailyDepositedBDV = ZERO_BI
         snapshot.dailyDepositedAmount = ZERO_BI
         snapshot.dailyWithdrawnAmount = ZERO_BI
         snapshot.dailyStalkDelta = ZERO_BI
         snapshot.dailySeedsDelta = ZERO_BI
+        snapshot.dailyFarmAmountDelta = ZERO_BI
         snapshot.blockNumber = ZERO_BI
-        snapshot.timestamp = ZERO_BI
+        snapshot.timestamp = BigInt.fromString(day)
+        snapshot.lastUpdated = ZERO_BI
         snapshot.save()
     }
     return snapshot as SiloAssetDailySnapshot

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -311,3 +311,25 @@ dataSources:
         - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
           handler: handleTransferSingle
       file: ./src/FertilizerHandler.ts
+  - kind: ethereum/contract
+    name: Farm
+    network: mainnet
+    source:
+      address: "0xC1E088fC1323b20BCBee9bd1B9fC9546db5624C5"
+      abi: Beanstalk
+      startBlock: 15277986
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - Farm
+      abis:
+        - name: Beanstalk
+          file: ./abis/Beanstalk-Replanted.json
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: InternalBalanceChanged(indexed address,indexed address,int256)
+          handler: handleInternalBalanceChanged
+      file: ./src/FarmHandler.ts

--- a/tests/silo-replanted/silo-replanted.test.ts
+++ b/tests/silo-replanted/silo-replanted.test.ts
@@ -9,7 +9,7 @@ describe("Mocked Events", () => {
     })
 
     describe("Bean", () => {
-        test("AddDeposit - Farmer Overall Silo Amounts", () => {
+        test("AddDeposit - Farm and Assets updated", () => {
 
             let account = '0x1234567890abcdef1234567890abcdef12345678'.toLowerCase()
             let token = BEAN_ERC20.toHexString().toLowerCase()
@@ -25,27 +25,9 @@ describe("Mocked Events", () => {
 
             handleAddDeposit(newAddDepositEvent)
 
-            assert.fieldEquals("Silo", account, "totalDepositedBDV", "1000000000")
-        })
-
-        test("AddDeposit - Farmer Silo Asset Amounts", () => {
-
-            let account = '0x1234567890abcdef1234567890abcdef12345678'.toLowerCase()
-            let token = BEAN_ERC20.toHexString().toLowerCase()
-
-            let newAddDepositEvent = createAddDepositEvent(
-                account,
-                token,
-                6100,
-                1000,
-                6,
-                1000
-            )
-
-            handleAddDeposit(newAddDepositEvent)
-
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedBDV", "1000000000")
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedAmount", "1000000000")
+            assert.fieldEquals("Farm", account, "totalDepositedBDV", "1000000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedBDV", "1000000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedAmount", "1000000000")
         })
 
         test("RemoveDeposit - Farmer Silo Amounts 50% Initial", () => {
@@ -67,17 +49,18 @@ describe("Mocked Events", () => {
             let newRemoveDepositEvent = createRemoveDepositEvent(
                 account,
                 token,
-                6150,
+                6100,
                 500,
                 6
             )
 
             handleRemoveDeposit(newRemoveDepositEvent)
 
+            assert.fieldEquals("Farm", account, "totalDepositedBDV", "500000000")
             assert.fieldEquals("SiloDeposit", account + '-' + token + '-6100', "removedTokenAmount", "500000000")
             assert.fieldEquals("SiloDeposit", account + '-' + token + '-6100', "removedBDV", "500000000")
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedBDV", "500000000")
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedAmount", "500000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedBDV", "500000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedAmount", "500000000")
         })
 
         test("RemoveDeposit - Farmer Silo Amounts 50% Remaining", () => {
@@ -116,10 +99,11 @@ describe("Mocked Events", () => {
 
             handleRemoveDeposit(secondRemoveDepositEvent)
 
+            assert.fieldEquals("Farm", account, "totalDepositedBDV", "250000000")
             assert.fieldEquals("SiloDeposit", account + '-' + token + '-6100', "removedTokenAmount", "750000000")
             assert.fieldEquals("SiloDeposit", account + '-' + token + '-6100', "removedBDV", "750000000")
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedBDV", "250000000")
-            assert.fieldEquals("SiloAsset", account + '-' + token, "totalDepositedAmount", "250000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedBDV", "250000000")
+            assert.fieldEquals("FarmAsset", account + '-' + token, "totalDepositedAmount", "250000000")
         })
     })
 })


### PR DESCRIPTION
- Treat minted beans as deposited on the protocol level at time of mint.
- Update `handlePlant` to account for this on the protocol level and the fact that an `AddDeposit` event will be emitted
- Add farm (internal) balances
- Update Silo timestamps to include a static timestamp based on snapshot, then a `lastUpdated` for tracking latest changes.
- Update npm scripts to deploy to new deployment targets

Resolves #10 #27 