### PR TITLE
Sunrise assets, Marketplace History

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -366,6 +366,7 @@ type FieldHourlySnapshot @entity {
   totalSoil: BigInt!
   podRate: BigDecimal!
   blocksToSoldOutSoil: BigInt!
+  soilSoldOut: Boolean!
   blockNumber: BigInt!
   timestamp: BigInt!
   lastUpdated: BigInt!
@@ -1034,6 +1035,8 @@ type PodOrderFilled implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  "Order ID filled"
+  orderID: String!
   "Account selling pods"
   from: String!
   "Account buying pods"

--- a/schema.graphql
+++ b/schema.graphql
@@ -572,6 +572,7 @@ type PodOrder @entity {
   createdAt: BigInt!
   updatedAt: BigInt!
   status: MarketStatus!
+  fill: PodFill
   amount: BigInt!
   filledAmount: BigInt!
   maxPlaceInLine: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -357,8 +357,10 @@ type FieldHourlySnapshot @entity {
   newSoil: BigInt!
   totalSoil: BigInt!
   podRate: BigDecimal!
+  blocksToSoldOutSoil: BigInt!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 type FieldDailySnapshot @entity {
@@ -385,6 +387,7 @@ type FieldDailySnapshot @entity {
   podRate: BigDecimal!
   blockNumber: BigInt!
   timestamp: BigInt!
+  lastUpdated: BigInt!
 }
 
 # ---===== Farmer Account Entities =====---

--- a/schema.graphql
+++ b/schema.graphql
@@ -42,6 +42,7 @@ enum MarketStatus {
   FILLED_PARTIAL
   CANCELLED
   CANCELLED_PARTIAL
+  EXPIRED
 }
 
 type Token @entity {
@@ -546,6 +547,8 @@ type PodMarketplaceDailySnapshot @entity {
 
 type PodListing @entity {
   id: ID! # the account plus index
+  " Historical ID for joins"
+  historyID: String!
   plot: Plot!
   farmer: Farmer!
   createdAt: BigInt!
@@ -568,6 +571,8 @@ type PodListing @entity {
 
 type PodOrder @entity {
   id: ID!
+  " Historical ID for joins"
+  historyID: String!
   farmer: Farmer!
   createdAt: BigInt!
   updatedAt: BigInt!
@@ -938,6 +943,8 @@ type PodListingCreated implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  " Historical ID for joins"
+  historyID: String!
   " Account creating the listing"
   account: String!
   " Index of the plot listed"
@@ -967,6 +974,8 @@ type PodListingFilled implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  " Historical ID for joins"
+  historyID: String!
   "Account selling pods"
   from: String!
   "Account buying pods"
@@ -992,6 +1001,8 @@ type PodListingCancelled implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  " Historical ID for joins"
+  historyID: String!
   " Account cancelling listing"
   account: String!
   " Index of plot listing being cancelled"
@@ -1011,6 +1022,8 @@ type PodOrderCreated implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  " Historical ID for joins"
+  historyID: String!
   " Account creating the listing"
   account: String!
   " ID of the pod order"
@@ -1036,8 +1049,8 @@ type PodOrderFilled implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
-  "Order ID filled"
-  orderID: String!
+  " Historical ID for joins"
+  historyID: String!
   "Account selling pods"
   from: String!
   "Account buying pods"
@@ -1063,6 +1076,8 @@ type PodOrderCancelled implements MarketplaceEvent @entity(immutable: true) {
   logIndex: Int!
   " The protocol this transaction belongs to "
   protocol: Beanstalk!
+  " Historical ID for joins"
+  historyID: String!
   " Account cancelling listing"
   account: String!
   " ID of order cancelled"

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,6 +36,14 @@ enum ProtocolType {
   # Will add more
 }
 
+enum MarketStatus {
+  ACTIVE
+  FILLED
+  FILLED_PARTIAL
+  CANCELLED
+  CANCELLED_PARTIAL
+}
+
 type Token @entity {
   " Smart contract address of the token "
   id: ID!
@@ -541,7 +549,7 @@ type PodListing @entity {
   farmer: Farmer!
   createdAt: BigInt!
   updatedAt: BigInt!
-  status: String!
+  status: MarketStatus!
   fill: PodFill
   originalIndex: BigInt!
   index: BigInt!
@@ -555,7 +563,6 @@ type PodListing @entity {
   pricePerPod: Int!
   maxHarvestableIndex: BigInt!
   mode: Int!
-  transaction: Transaction
 }
 
 type PodOrder @entity {
@@ -563,17 +570,17 @@ type PodOrder @entity {
   farmer: Farmer!
   createdAt: BigInt!
   updatedAt: BigInt!
-  status: String!
+  status: MarketStatus!
   amount: BigInt!
   filledAmount: BigInt!
   maxPlaceInLine: BigInt!
   pricePerPod: Int!
-  transaction: Transaction
 }
 
 type PodFill @entity {
   id: ID!
   podMarketplace: PodMarketplace!
+  createdAt: BigInt!
   listing: PodListing
   order: PodOrder
   from: String!
@@ -581,7 +588,6 @@ type PodFill @entity {
   amount: BigInt!
   index: BigInt!
   start: BigInt!
-  transaction: Transaction
 }
 
 type Transaction @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -166,6 +166,7 @@ type Silo @entity {
   id: ID!
   beanstalk: Beanstalk!
   farmer: Farmer
+  whitelistedTokens: [String!]!
   assets: [SiloAsset!]! @derivedFrom(field: "silo")
   totalValueLockedUSD: BigDecimal!
   totalDepositedBDV: BigInt!
@@ -398,6 +399,7 @@ type Farmer @entity {
   field: Field @derivedFrom(field: "farmer")
   plots: [Plot!]! @derivedFrom(field: "farmer")
   listings: [PodListing!]! @derivedFrom(field: "farmer")
+  orders: [PodOrder!]! @derivedFrom(field: "farmer")
   sown: Boolean!
   fertilizers: [FertilizerBalance!]! @derivedFrom(field: "farmer")
 }
@@ -1052,6 +1054,46 @@ type PodOrderCancelled implements MarketplaceEvent @entity(immutable: true) {
   account: String!
   " ID of order cancelled"
   orderId: String!
+  " Block number of this event "
+  blockNumber: BigInt!
+  " Timestamp of this event "
+  timestamp: BigInt!
+}
+
+type WhitelistToken implements SiloEvent @entity(immutable: true) {
+  "whitelistToken-{ Transaction hash }-{ Log index }"
+  id: ID!
+  " Transaction hash of the transaction that emitted this event "
+  hash: String!
+  " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
+  logIndex: Int!
+  " The protocol this transaction belongs to "
+  protocol: Beanstalk!
+  "Token address whitelisted"
+  token: String!
+  "Stalk per BDV"
+  stalk: BigInt!
+  "Seeds per BDV"
+  seeds: BigInt!
+  "Selector for token"
+  selector: String!
+  " Block number of this event "
+  blockNumber: BigInt!
+  " Timestamp of this event "
+  timestamp: BigInt!
+}
+
+type DewhitelistToken implements SiloEvent @entity(immutable: true) {
+  "dewhitelistToken-{ Transaction hash }-{ Log index }"
+  id: ID!
+  " Transaction hash of the transaction that emitted this event "
+  hash: String!
+  " Event log index. For transactions that don't emit event, create arbitrary index starting from 0 "
+  logIndex: Int!
+  " The protocol this transaction belongs to "
+  protocol: Beanstalk!
+  "Token address dewhitelisted"
+  token: String!
   " Block number of this event "
   blockNumber: BigInt!
   " Timestamp of this event "

--- a/src/FieldHandler.ts
+++ b/src/FieldHandler.ts
@@ -405,7 +405,7 @@ function updateFieldTotals(
     fieldHourly.newHarvestedPods = fieldHourly.newHarvestedPods.plus(harvestedPods)
     fieldHourly.blockNumber = fieldHourly.blockNumber == ZERO_BI ? blockNumber : fieldHourly.blockNumber
     fieldHourly.lastUpdated = timestamp
-    if (fieldHourly.newSoil == fieldHourly.sownBeans) fieldHourly.blocksToSoldOutSoil = blockNumber.minus(fieldHourly.blockNumber)
+    if (field.totalSoil == ZERO_BI) fieldHourly.blocksToSoldOutSoil = blockNumber.minus(fieldHourly.blockNumber)
     fieldHourly.save()
 
     fieldDaily.totalSoil = field.totalSoil
@@ -419,8 +419,8 @@ function updateFieldTotals(
     fieldDaily.newPods = fieldDaily.newPods.plus(sownPods).minus(harvestablePods).plus(transferredPods)
     fieldDaily.newHarvestablePods = fieldDaily.newHarvestablePods.plus(harvestablePods)
     fieldDaily.newHarvestedPods = fieldDaily.newHarvestedPods.plus(harvestedPods)
-    fieldDaily.blockNumber = blockNumber
-    fieldDaily.timestamp = timestamp
+    fieldDaily.blockNumber = fieldDaily.blockNumber == ZERO_BI ? blockNumber : fieldDaily.blockNumber
+    fieldDaily.lastUpdated = timestamp
     fieldDaily.save()
 }
 

--- a/src/FieldHandler.ts
+++ b/src/FieldHandler.ts
@@ -403,8 +403,9 @@ function updateFieldTotals(
     fieldHourly.newPods = fieldHourly.newPods.plus(sownPods).minus(harvestablePods).plus(transferredPods)
     fieldHourly.newHarvestablePods = fieldHourly.newHarvestablePods.plus(harvestablePods)
     fieldHourly.newHarvestedPods = fieldHourly.newHarvestedPods.plus(harvestedPods)
-    fieldHourly.blockNumber = blockNumber
-    fieldHourly.timestamp = timestamp
+    fieldHourly.blockNumber = fieldHourly.blockNumber == ZERO_BI ? blockNumber : fieldHourly.blockNumber
+    fieldHourly.lastUpdated = timestamp
+    if (fieldHourly.newSoil == fieldHourly.sownBeans) fieldHourly.blocksToSoldOutSoil = blockNumber.minus(fieldHourly.blockNumber)
     fieldHourly.save()
 
     fieldDaily.totalSoil = field.totalSoil

--- a/src/FieldHandler.ts
+++ b/src/FieldHandler.ts
@@ -405,7 +405,10 @@ function updateFieldTotals(
     fieldHourly.newHarvestedPods = fieldHourly.newHarvestedPods.plus(harvestedPods)
     fieldHourly.blockNumber = fieldHourly.blockNumber == ZERO_BI ? blockNumber : fieldHourly.blockNumber
     fieldHourly.lastUpdated = timestamp
-    if (field.totalSoil == ZERO_BI) fieldHourly.blocksToSoldOutSoil = blockNumber.minus(fieldHourly.blockNumber)
+    if (field.totalSoil == ZERO_BI) {
+        fieldHourly.blocksToSoldOutSoil = blockNumber.minus(fieldHourly.blockNumber)
+        fieldHourly.soilSoldOut = true
+    }
     fieldHourly.save()
 
     fieldDaily.totalSoil = field.totalSoil

--- a/src/MarketplaceHandler.ts
+++ b/src/MarketplaceHandler.ts
@@ -32,6 +32,7 @@ export function handlePodListingCreated(event: PodListingCreated): void {
         listing.createdAt = ZERO_BI
     }
 
+    listing.historyID = listing.id + '-' + event.block.timestamp.toString()
     listing.plot = plot.id
     listing.createdAt = listing.createdAt == ZERO_BI ? event.block.timestamp : listing.createdAt
     listing.updatedAt = event.block.timestamp
@@ -80,6 +81,7 @@ export function handlePodListingCreated(event: PodListingCreated): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = listing.historyID
     rawEvent.account = event.params.account.toHexString()
     rawEvent.index = event.params.index
     rawEvent.start = event.params.start
@@ -124,6 +126,7 @@ export function handlePodListingCancelled(event: PodListingCancelled): void {
     listing.status = 'CANCELLED'
     listing.cancelledAmount = listing.remainingAmount
     listing.remainingAmount = ZERO_BI
+    listing.updatedAt = event.block.timestamp
     listing.save()
 
     // Save the raw event data
@@ -132,6 +135,7 @@ export function handlePodListingCancelled(event: PodListingCancelled): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = listing.historyID
     rawEvent.account = event.params.account.toHexString()
     rawEvent.index = event.params.index
     rawEvent.blockNumber = event.block.number
@@ -183,6 +187,7 @@ export function handlePodListingFilled(event: PodListingFilled): void {
     listing.remainingAmount = listing.remainingAmount.minus(event.params.amount)
     listing.totalFilled = listing.totalFilled.plus(event.params.amount)
 
+    let originalHistoryID = listing.historyID
     let listingIndex = market.listingIndexes.indexOf(listing.index)
     market.listingIndexes.splice(listingIndex, 1)
     if (listing.remainingAmount == ZERO_BI) {
@@ -191,6 +196,7 @@ export function handlePodListingFilled(event: PodListingFilled): void {
         listing.status = 'FILLED_PARTIAL'
         let remainingListing = loadPodListing(Address.fromString(listing.farmer), listing.index.plus(event.params.amount).plus(listing.start))
 
+        remainingListing.historyID = remainingListing.id + '-' + event.block.timestamp.toString()
         remainingListing.plot = listing.index.plus(event.params.amount).plus(listing.start).toString()
         remainingListing.createdAt = listing.createdAt
         remainingListing.updatedAt = event.block.timestamp
@@ -225,6 +231,7 @@ export function handlePodListingFilled(event: PodListingFilled): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = originalHistoryID
     rawEvent.from = event.params.from.toHexString()
     rawEvent.to = event.params.to.toHexString()
     rawEvent.index = event.params.index
@@ -245,6 +252,7 @@ export function handlePodOrderCreated(event: PodOrderCreated): void {
 
     if (order.status != '') { createHistoricalPodOrder(order) }
 
+    order.historyID = order.id + '-' + event.block.timestamp.toString()
     order.farmer = event.params.account.toHexString()
     order.createdAt = event.block.timestamp
     order.updatedAt = event.block.timestamp
@@ -273,6 +281,7 @@ export function handlePodOrderCreated(event: PodOrderCreated): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = order.historyID
     rawEvent.account = event.params.account.toHexString()
     rawEvent.orderId = event.params.id.toHexString()
     rawEvent.amount = event.params.amount
@@ -342,7 +351,7 @@ export function handlePodOrderFilled(event: PodOrderFilled): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
-    rawEvent.orderID = order.id
+    rawEvent.historyID = order.historyID
     rawEvent.from = event.params.from.toHexString()
     rawEvent.to = event.params.to.toHexString()
     rawEvent.index = event.params.index
@@ -385,6 +394,7 @@ export function handlePodOrderCancelled(event: PodOrderCancelled): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = order.historyID
     rawEvent.account = event.params.account.toHexString()
     rawEvent.orderId = event.params.id.toHexString()
     rawEvent.blockNumber = event.block.number

--- a/src/MarketplaceHandler.ts
+++ b/src/MarketplaceHandler.ts
@@ -186,6 +186,7 @@ export function handlePodListingFilled(event: PodListingFilled): void {
     listing.filledAmount = event.params.amount
     listing.remainingAmount = listing.remainingAmount.minus(event.params.amount)
     listing.totalFilled = listing.totalFilled.plus(event.params.amount)
+    listing.updatedAt = event.block.timestamp
 
     let originalHistoryID = listing.historyID
     let listingIndex = market.listingIndexes.indexOf(listing.index)

--- a/src/MarketplaceHandler.ts
+++ b/src/MarketplaceHandler.ts
@@ -243,7 +243,7 @@ export function handlePodOrderCreated(event: PodOrderCreated): void {
     let order = loadPodOrder(event.params.id)
     let farmer = loadFarmer(event.params.account)
 
-    if (order.createdAt !== event.block.timestamp) { createHistoricalPodOrder(order) }
+    if (order.status != '') { createHistoricalPodOrder(order) }
 
     order.farmer = event.params.account.toHexString()
     order.createdAt = event.block.timestamp
@@ -342,6 +342,7 @@ export function handlePodOrderFilled(event: PodOrderFilled): void {
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.orderID = order.id
     rawEvent.from = event.params.from.toHexString()
     rawEvent.to = event.params.to.toHexString()
     rawEvent.index = event.params.index

--- a/src/MarketplaceReplantedHandler.ts
+++ b/src/MarketplaceReplantedHandler.ts
@@ -21,6 +21,7 @@ export function handlePodListingCreated(event: PodListingCreated): void {
         listing.createdAt = ZERO_BI
     }
 
+    listing.historyID = listing.id + '-' + event.block.timestamp.toString()
     listing.plot = plot.id
     listing.createdAt = listing.createdAt == ZERO_BI ? event.block.timestamp : listing.createdAt
     listing.updatedAt = event.block.timestamp
@@ -65,11 +66,12 @@ export function handlePodListingCreated(event: PodListingCreated): void {
     marketDaily.save()
 
     // Save the raw event data
-    let id = 'podListingCreated' + event.transaction.hash.toHexString() + '-' + event.logIndex.toString()
+    let id = 'podListingCreated-' + event.transaction.hash.toHexString() + '-' + event.logIndex.toString()
     let rawEvent = new PodListingCreatedEvent(id)
     rawEvent.hash = event.transaction.hash.toHexString()
     rawEvent.logIndex = event.logIndex.toI32()
     rawEvent.protocol = event.address.toHexString()
+    rawEvent.historyID = listing.historyID
     rawEvent.account = event.params.account.toHexString()
     rawEvent.index = event.params.index
     rawEvent.start = event.params.start

--- a/src/MarketplaceReplantedHandler.ts
+++ b/src/MarketplaceReplantedHandler.ts
@@ -7,7 +7,6 @@ import { loadPodMarketplace, loadPodMarketplaceDailySnapshot, loadPodMarketplace
 import { loadTransaction } from "./utils/Transaction";
 
 export function handlePodListingCreated(event: PodListingCreated): void {
-    let transaction = loadTransaction(event.transaction, event.block)
     let market = loadPodMarketplace(event.address)
     let marketHourly = loadPodMarketplaceHourlySnapshot(event.address, market.season, event.block.timestamp)
     let marketDaily = loadPodMarketplaceDailySnapshot(event.address, event.block.timestamp)
@@ -25,7 +24,7 @@ export function handlePodListingCreated(event: PodListingCreated): void {
     listing.plot = plot.id
     listing.createdAt = listing.createdAt == ZERO_BI ? event.block.timestamp : listing.createdAt
     listing.updatedAt = event.block.timestamp
-    listing.status = 'active'
+    listing.status = 'ACTIVE'
     listing.originalIndex = event.params.index
     listing.start = event.params.start
     listing.amount = event.params.amount
@@ -34,7 +33,6 @@ export function handlePodListingCreated(event: PodListingCreated): void {
     listing.pricePerPod = event.params.pricePerPod
     listing.maxHarvestableIndex = event.params.maxHarvestableIndex
     listing.mode = event.params.mode
-    listing.transaction = transaction.id
     listing.save()
 
     plot.listing = listing.id

--- a/src/SeasonHandler.ts
+++ b/src/SeasonHandler.ts
@@ -15,6 +15,7 @@ import { loadSeason } from "./utils/Season";
 import { loadSilo, loadSiloDailySnapshot, loadSiloHourlySnapshot } from "./utils/Silo";
 import { addDepositToSiloAsset, updateStalkWithCalls } from "./SiloHandler";
 import { updateBeanEMA } from "./YieldHandler";
+import { loadSiloAssetDailySnapshot, loadSiloAssetHourlySnapshot } from "./utils/SiloAsset";
 
 export function handleSunrise(event: Sunrise): void {
     let currentSeason = event.params.season.toI32()
@@ -79,9 +80,11 @@ export function handleSunrise(event: Sunrise): void {
 
     // Create silo entities for the protocol
     let silo = loadSilo(event.address)
+    loadSiloHourlySnapshot(event.address, currentSeason, event.block.timestamp)
+    loadSiloDailySnapshot(event.address, event.block.timestamp)
     for (let i = 0; i < silo.whitelistedTokens.length; i++) {
-        loadSiloHourlySnapshot(event.address, currentSeason, event.block.timestamp)
-        loadSiloDailySnapshot(event.address, event.block.timestamp)
+        loadSiloAssetHourlySnapshot(event.address, Address.fromString(silo.whitelistedTokens[i]), currentSeason, event.block.timestamp)
+        loadSiloAssetDailySnapshot(event.address, Address.fromString(silo.whitelistedTokens[i]), event.block.timestamp)
     }
 }
 

--- a/src/SeasonHandler.ts
+++ b/src/SeasonHandler.ts
@@ -76,6 +76,13 @@ export function handleSunrise(event: Sunrise): void {
 
     market.listingIndexes = remainingListings
     market.save()
+
+    // Create silo entities for the protocol
+    let silo = loadSilo(event.address)
+    for (let i = 0; i < silo.whitelistedTokens.length; i++) {
+        loadSiloHourlySnapshot(event.address, currentSeason, event.block.timestamp)
+        loadSiloDailySnapshot(event.address, event.block.timestamp)
+    }
 }
 
 export function handleSeasonSnapshot(event: SeasonSnapshot): void {

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -7,6 +7,8 @@ export const ADDRESS_ZERO = Address.fromString('0x000000000000000000000000000000
 export const BEAN_ERC20_V1 = Address.fromString('0xDC59ac4FeFa32293A95889Dc396682858d52e5Db')
 export const BEAN_ERC20 = Address.fromString('0xBEA0000029AD1c77D3d5D23Ba2D8893dB9d1Efab')
 export const UNRIPE_BEAN = Address.fromString('0x1bea0050e63e05fbb5d8ba2f10cf5800b6224449')
+export const BEAN_3CRV = Address.fromString('0xc9C32cd16Bf7eFB85Ff14e0c8603cc90F6F2eE49')
+export const UNRIPE_BEAN_3CRV = Address.fromString('0x1BEA3CcD22F4EBd3d37d731BA31Eeca95713716D')
 export const BEANSTALK_FARMS = Address.fromString('0x21de18b6a8f78ede6d16c50a167f6b222dc08df7')
 
 // Protocol Addresses

--- a/src/utils/Field.ts
+++ b/src/utils/Field.ts
@@ -54,8 +54,10 @@ export function loadFieldHourly(diamondAddress: Address, season: i32, timestamp:
         hourly.newSoil = ZERO_BI
         hourly.totalSoil = ZERO_BI
         hourly.podRate = field.podRate
+        hourly.blocksToSoldOutSoil = ZERO_BI
         hourly.blockNumber = ZERO_BI
         hourly.timestamp = timestamp
+        hourly.lastUpdated = timestamp
         hourly.save()
     }
     return hourly
@@ -90,6 +92,7 @@ export function loadFieldDaily(diamondAddress: Address, timestamp: BigInt): Fiel
         daily.podRate = field.podRate
         daily.blockNumber = ZERO_BI
         daily.timestamp = timestamp
+        daily.lastUpdated = timestamp
         daily.save()
     }
     return daily

--- a/src/utils/Field.ts
+++ b/src/utils/Field.ts
@@ -55,6 +55,7 @@ export function loadFieldHourly(diamondAddress: Address, season: i32, timestamp:
         hourly.totalSoil = ZERO_BI
         hourly.podRate = field.podRate
         hourly.blocksToSoldOutSoil = ZERO_BI
+        hourly.soilSoldOut = false
         hourly.blockNumber = ZERO_BI
         hourly.timestamp = timestamp
         hourly.lastUpdated = timestamp

--- a/src/utils/PodFill.ts
+++ b/src/utils/PodFill.ts
@@ -8,6 +8,7 @@ export function loadPodFill(diamondAddress: Address, index: BigInt, hash: String
     if (fill == null) {
         fill = new PodFill(id)
         fill.podMarketplace = diamondAddress.toHexString()
+        fill.createdAt = ZERO_BI
         fill.from = ''
         fill.to = ''
         fill.amount = ZERO_BI

--- a/src/utils/PodListing.ts
+++ b/src/utils/PodListing.ts
@@ -13,7 +13,7 @@ export function loadPodListing(account: Address, index: BigInt): PodListing {
         listing.farmer = account.toHexString()
         listing.createdAt = ZERO_BI
         listing.updatedAt = ZERO_BI
-        listing.status = 'active'
+        listing.status = 'ACTIVE'
         listing.originalIndex = index
         listing.index = index
         listing.start = ZERO_BI

--- a/src/utils/PodListing.ts
+++ b/src/utils/PodListing.ts
@@ -9,6 +9,7 @@ export function loadPodListing(account: Address, index: BigInt): PodListing {
     let listing = PodListing.load(id)
     if (listing == null) {
         listing = new PodListing(id)
+        listing.historyID = ''
         listing.plot = index.toString()
         listing.farmer = account.toHexString()
         listing.createdAt = ZERO_BI
@@ -57,7 +58,7 @@ export function expirePodListing(diamondAddress: Address, timestamp: BigInt, lis
     marketDaily.totalPodsAvailable = market.totalPodsAvailable
     marketDaily.save()
 
-    listing.status = 'expired'
+    listing.status = 'EXPIRED'
     listing.remainingAmount = ZERO_BI
     listing.save()
 }
@@ -66,10 +67,11 @@ export function createHistoricalPodListing(listing: PodListing): void {
     let created = false
     let id = listing.id
     for (let i = 0; !created; i++) {
-        id = id + '-' + i.toString()
+        id = listing.id + '-' + i.toString()
         let newListing = PodListing.load(id)
         if (newListing == null) {
             newListing = new PodListing(id)
+            newListing.historyID = listing.historyID
             newListing.plot = listing.plot
             newListing.farmer = listing.farmer
             newListing.createdAt = listing.createdAt

--- a/src/utils/PodOrder.ts
+++ b/src/utils/PodOrder.ts
@@ -6,6 +6,7 @@ export function loadPodOrder(orderID: Bytes): PodOrder {
     let order = PodOrder.load(orderID.toHexString())
     if (order == null) {
         order = new PodOrder(orderID.toHexString())
+        order.historyID = ''
         order.farmer = ''
         order.createdAt = ZERO_BI
         order.updatedAt = ZERO_BI
@@ -23,10 +24,11 @@ export function createHistoricalPodOrder(order: PodOrder): void {
     let created = false
     let id = order.id
     for (let i = 0; !created; i++) {
-        id = id + '-' + i.toString()
+        id = order.id + '-' + i.toString()
         let newOrder = PodOrder.load(id)
         if (newOrder == null) {
             newOrder = new PodOrder(id)
+            newOrder.historyID = order.historyID
             newOrder.farmer = order.farmer
             newOrder.createdAt = order.createdAt
             newOrder.updatedAt = order.updatedAt

--- a/src/utils/PodOrder.ts
+++ b/src/utils/PodOrder.ts
@@ -9,7 +9,7 @@ export function loadPodOrder(orderID: Bytes): PodOrder {
         order.farmer = ''
         order.createdAt = ZERO_BI
         order.updatedAt = ZERO_BI
-        order.status = 'ACTIVE'
+        order.status = ''
         order.amount = ZERO_BI
         order.filledAmount = ZERO_BI
         order.maxPlaceInLine = ZERO_BI

--- a/src/utils/PodOrder.ts
+++ b/src/utils/PodOrder.ts
@@ -9,7 +9,7 @@ export function loadPodOrder(orderID: Bytes): PodOrder {
         order.farmer = ''
         order.createdAt = ZERO_BI
         order.updatedAt = ZERO_BI
-        order.status = ''
+        order.status = 'ACTIVE'
         order.amount = ZERO_BI
         order.filledAmount = ZERO_BI
         order.maxPlaceInLine = ZERO_BI

--- a/src/utils/Silo.ts
+++ b/src/utils/Silo.ts
@@ -10,6 +10,7 @@ export function loadSilo(account: Address): Silo {
         silo = new Silo(account.toHexString())
         silo.beanstalk = BEANSTALK.toHexString()
         if (account !== BEANSTALK) { silo.farmer = account.toHexString() }
+        silo.whitelistedTokens = []
         silo.totalValueLockedUSD = ZERO_BD
         silo.totalDepositedBDV = ZERO_BI
         silo.totalStalk = ZERO_BI

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -41,6 +41,10 @@ dataSources:
           handler: handleStalkBalanceChanged
         - event: Plant(indexed address,uint256)
           handler: handlePlant
+        - event: WhitelistToken(indexed address,bytes4,uint256,uint256)
+          handler: handleWhitelistToken
+        - event: DewhitelistToken(indexed address)
+          handler: handleDewhitelistToken
       file: ./src/SiloHandler.ts
   # Field - Original
   - kind: ethereum/contract


### PR DESCRIPTION
- Update marketplace entities to use MarketStatus enum
- Add soil sold out bool and number of blocks to FieldHourlySnapshot
- Create new silo and silo asset snapshots for the protocol level for every season, regardless of overall activity.
- Total farmers with stalk added to siloHourlySnapshot
- Save whitelisted tokens so that snapshots are triggered accordingly. 
- Unripe tokens are included in the snapshot creation
- Pod Market History (event) entities
- historyID update for marketplace events so we can do an appropriate join for frontend

Resolves #33 , #31, #23