### PR TITLE
Exclude double processing of re-emitted events

### DIFF
--- a/src/SeasonHandler.ts
+++ b/src/SeasonHandler.ts
@@ -117,9 +117,10 @@ export function handleReward(event: Reward): void {
     let silo = loadSilo(event.address)
     let siloHourly = loadSiloHourlySnapshot(event.address, season.season, event.block.timestamp)
     let siloDaily = loadSiloDailySnapshot(event.address, event.block.timestamp)
+    let newPlantableStalk = event.params.toSilo.times(BigInt.fromI32(10000)) // Stalk has 10 decimals
 
     silo.totalBeanMints = silo.totalBeanMints.plus(event.params.toSilo)
-    silo.totalPlantableStalk = silo.totalPlantableStalk.plus(event.params.toSilo)
+    silo.totalPlantableStalk = silo.totalPlantableStalk.plus(newPlantableStalk)
     silo.totalDepositedBDV = silo.totalDepositedBDV.plus(event.params.toSilo)
     silo.save()
 
@@ -127,7 +128,7 @@ export function handleReward(event: Reward): void {
     siloHourly.totalPlantableStalk = silo.totalPlantableStalk
     siloHourly.totalDepositedBDV = silo.totalDepositedBDV
     siloHourly.hourlyBeanMints = siloHourly.hourlyBeanMints.plus(event.params.toSilo)
-    siloHourly.hourlyPlantableStalkDelta = siloHourly.hourlyPlantableStalkDelta.plus(event.params.toSilo)
+    siloHourly.hourlyPlantableStalkDelta = siloHourly.hourlyPlantableStalkDelta.plus(newPlantableStalk)
     siloHourly.hourlyDepositedBDV = siloHourly.hourlyDepositedBDV.plus(event.params.toSilo)
     siloHourly.save()
 
@@ -135,7 +136,7 @@ export function handleReward(event: Reward): void {
     siloDaily.totalPlantableStalk = silo.totalPlantableStalk
     siloDaily.totalDepositedBDV = silo.totalDepositedBDV
     siloDaily.dailyBeanMints = siloDaily.dailyBeanMints.plus(event.params.toSilo)
-    siloDaily.dailyPlantableStalkDelta = siloDaily.dailyPlantableStalkDelta.plus(event.params.toSilo)
+    siloDaily.dailyPlantableStalkDelta = siloDaily.dailyPlantableStalkDelta.plus(newPlantableStalk)
     siloDaily.dailyDepositedBDV = siloDaily.dailyDepositedBDV.plus(event.params.toSilo)
     siloDaily.save()
 

--- a/src/SiloHandler.ts
+++ b/src/SiloHandler.ts
@@ -171,6 +171,8 @@ export function handleRemoveWithdrawals(event: RemoveWithdrawals): void {
 }
 
 export function handleStalkBalanceChanged(event: StalkBalanceChanged): void {
+    // Exclude BIP-24 emission of missed past events
+    if (event.transaction.hash.toHexString() == '0xa89638aeb0d6c4afb4f367ea7a806a4c8b3b2a6eeac773e8cc4eda10bfa804fc') return
 
     let beanstalk = loadBeanstalk(event.address) // get current season
     updateStalkBalances(event.address, beanstalk.lastSeason, event.params.delta, event.params.deltaRoots, event.block.timestamp, event.block.number)
@@ -190,6 +192,8 @@ export function handleStalkBalanceChanged(event: StalkBalanceChanged): void {
 }
 
 export function handleSeedsBalanceChanged(event: StalkBalanceChanged): void {
+    // Exclude BIP-24 emission of missed past events
+    if (event.transaction.hash.toHexString() == '0xa89638aeb0d6c4afb4f367ea7a806a4c8b3b2a6eeac773e8cc4eda10bfa804fc') return
 
     let beanstalk = loadBeanstalk(event.address) // get current season
     updateSeedsBalances(event.address, beanstalk.lastSeason, event.params.delta, event.block.timestamp, event.block.number)
@@ -216,14 +220,15 @@ export function handlePlant(event: Plant): void {
     let silo = loadSilo(event.address)
     let siloHourly = loadSiloHourlySnapshot(event.address, beanstalk.lastSeason, event.block.timestamp)
     let siloDaily = loadSiloDailySnapshot(event.address, event.block.timestamp)
+    let newPlantableStalk = event.params.beans.times(BigInt.fromI32(10000))
 
-    silo.totalPlantableStalk = silo.totalPlantableStalk.minus(event.params.beans)
+    silo.totalPlantableStalk = silo.totalPlantableStalk.minus(newPlantableStalk)
     silo.totalDepositedBDV = silo.totalDepositedBDV.minus(event.params.beans)
     silo.save()
 
     siloHourly.totalPlantableStalk = silo.totalPlantableStalk
     siloHourly.totalDepositedBDV = silo.totalDepositedBDV
-    siloHourly.hourlyPlantableStalkDelta = siloHourly.hourlyPlantableStalkDelta.minus(event.params.beans)
+    siloHourly.hourlyPlantableStalkDelta = siloHourly.hourlyPlantableStalkDelta.minus(newPlantableStalk)
     siloHourly.hourlyDepositedBDV = siloHourly.hourlyDepositedBDV.minus(event.params.beans)
     siloHourly.blockNumber = event.block.number
     siloHourly.lastUpdated = event.block.timestamp
@@ -231,7 +236,7 @@ export function handlePlant(event: Plant): void {
 
     siloDaily.totalPlantableStalk = silo.totalPlantableStalk
     siloDaily.totalDepositedBDV = silo.totalDepositedBDV
-    siloDaily.dailyPlantableStalkDelta = siloDaily.dailyPlantableStalkDelta.minus(event.params.beans)
+    siloDaily.dailyPlantableStalkDelta = siloDaily.dailyPlantableStalkDelta.minus(newPlantableStalk)
     siloDaily.dailyDepositedBDV = siloDaily.dailyDepositedBDV.minus(event.params.beans)
     siloDaily.blockNumber = event.block.number
     siloDaily.lastUpdated = event.block.timestamp


### PR DESCRIPTION
Correct plantable stalk decimals. Closes #35 